### PR TITLE
Replace modern Number checks with legacy-compatible alternatives

### DIFF
--- a/impostor_game.html
+++ b/impostor_game.html
@@ -326,13 +326,13 @@
 
       playersInput.addEventListener("input", (event) => {
         const value = parseInt(event.target.value, 10);
-        state.numJugadores = Number.isNaN(value) ? 0 : value;
+        state.numJugadores = isNaN(value) ? 0 : value;
         render();
       });
 
       impostorsInput.addEventListener("input", (event) => {
         const value = parseInt(event.target.value, 10);
-        state.numImpostores = Number.isNaN(value) ? 0 : value;
+        state.numImpostores = isNaN(value) ? 0 : value;
         render();
       });
 
@@ -405,7 +405,7 @@
         impostorsInput.value = state.numImpostores || "";
 
         const total = state.numJugadores + state.numImpostores;
-        totalSpan.textContent = Number.isFinite(total) ? total : 0;
+        totalSpan.textContent = isFinite(total) ? total : 0;
 
         const invalid = isConfigInvalid();
         startBtn.disabled = invalid;


### PR DESCRIPTION
## Summary
- replace Number.isNaN usages with the global isNaN helper for legacy browser support
- switch the total display check to the global isFinite helper to avoid Number namespace dependencies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ca1fd63ed0832a907e897ce07f0996