### PR TITLE
Handle numeric inputs on input and change events

### DIFF
--- a/impostor_game.html
+++ b/impostor_game.html
@@ -324,17 +324,22 @@
       const newConfigBtn = document.getElementById("new-config-btn");
       const restartBtn = document.getElementById("restart-btn");
 
-      playersInput.addEventListener("input", (event) => {
+      function updateNumericState(event, key) {
         const value = parseInt(event.target.value, 10);
-        state.numJugadores = isNaN(value) ? 0 : value;
+        state[key] = Number.isNaN(value) ? 0 : value;
         render();
-      });
+      }
 
-      impostorsInput.addEventListener("input", (event) => {
-        const value = parseInt(event.target.value, 10);
-        state.numImpostores = isNaN(value) ? 0 : value;
-        render();
-      });
+      function bindNumericInput(element, key) {
+        ["input", "change"].forEach((eventType) => {
+          element.addEventListener(eventType, (event) =>
+            updateNumericState(event, key)
+          );
+        });
+      }
+
+      bindNumericInput(playersInput, "numJugadores");
+      bindNumericInput(impostorsInput, "numImpostores");
 
       startBtn.addEventListener("click", startGame);
       nextBtn.addEventListener("click", nextStep);


### PR DESCRIPTION
## Summary
- extract numeric input parsing into a reusable helper
- attach both `input` and `change` listeners for the player and impostor fields so the UI updates reliably

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ca29a48ab8832a94f793909e4d19bb